### PR TITLE
Support jwt, commandline args, and device ids

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gomake-mock-data",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Mock Telemetry and Flight Data",
   "main": "lib/index.js",
   "engines": {


### PR DESCRIPTION
Adds support for JWT to the URL and updates to latest form of telemetry URL. Can make this more flexible in the future.

Command line args work like *this*:
```python devices/rockblock.py -u http://localhost:3000 -f GOMAKE-1```
where
```
-u / --url = base url for gomake-api running
-f/--flightname = flight name with flight number (i.e. GOMAKE-1)
```
renamed outgoing message to support 'device_id' format. linked to PR in gomake-api to support the same. IMEI is too specific a device identification standard; in the future we should generate a uuid from the IMEI and send as a uuid instead to support a better global name structure for device identifiers.

@morrissinger @nehaabrol87 
